### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
 
+    // REST Repositories & REST Repository HAL Exploer
+    // HAL Explorer로 생성되어있는 페이지로 테스트 진행
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/org/board/boardproject/repository/ArticleCommentRepository.java
+++ b/src/main/java/org/board/boardproject/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package org.board.boardproject.repository;
 
 import org.board.boardproject.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/org/board/boardproject/repository/ArticleRepository.java
+++ b/src/main/java/org/board/boardproject/repository/ArticleRepository.java
@@ -2,6 +2,9 @@ package org.board.boardproject.repository;
 
 import org.board.boardproject.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+// spring Data REST 사용하는 어노테이션 yml파일에 annotation으로 지정하였기 때문에 어노테이션으로 지정해야한다
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,9 @@ spring:
   # h2 console url connect false -> true change
   h2.console.enabled: false
   sql.init.mode: always
-
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated
 ---
 
 #spring:

--- a/src/test/java/org/board/boardproject/controller/DataRestTest.java
+++ b/src/test/java/org/board/boardproject/controller/DataRestTest.java
@@ -1,0 +1,71 @@
+package org.board.boardproject.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+@DisplayName("Data Rest - API Test")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+    private final MockMvc mvc;
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[API] 게시글 LIST 조회")
+    @Test
+    void givenNothing_whenRequestArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        // Given
+        // When & Then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[API] 게시글 단건 조회")
+    @Test
+    void givenNothing_whenRequestArticle_thenReturnsArticleJsonResponse() throws Exception {
+        // Given
+        // When & Then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+    @DisplayName("[API] 게시글 -> 댓글 조회")
+    @Test
+    void givenNothing_whenRequestArticleCommentFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // Given
+        // When & Then
+        mvc.perform(get("/api/articles/5/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+    @DisplayName("[API] 댓글 리스트")
+    @Test
+    void givenNothing_whenRequestArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // Given
+        // When & Then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+    @DisplayName("[API] 댓글 단건 리스트")
+    @Test
+    void givenNothing_whenRequestArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        // Given
+        // When & Then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 api 들의 존재 여부만 확인하도록 통합 테스트 작성

- 추가 커밋 내용
1. data rest 설정 : 게시글, 댓글 json api를 자동으로 restful하게 끔 설정 
2. data rest 테스트 : DB접근을 막기 위해 `@Transactional` 적용하여 테스트 안에서는 롤백 정책으로 동작